### PR TITLE
fix: mermaid dark theme for slate palette

### DIFF
--- a/docs/javascripts/mermaid-dark.mjs
+++ b/docs/javascripts/mermaid-dark.mjs
@@ -1,0 +1,10 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: "dark",
+  securityLevel: "loose",
+});
+
+// Material detects window.mermaid and uses it instead of loading its own copy
+window.mermaid = mermaid;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid_custom
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - attr_list
@@ -32,7 +32,7 @@ markdown_extensions:
 
 plugins:
   - search
-  - mermaid2
+
 
 nav:
   - Home: index.md
@@ -43,3 +43,6 @@ nav:
       - Architecture Patterns: framework/patterns.md
   - Case Studies:
       - EU Battery Regulation: cases/battery-regulation.md
+
+extra_javascript:
+  - javascripts/mermaid-dark.mjs


### PR DESCRIPTION
## Summary
- Drop mermaid2 plugin (renders with default light theme on dark background)
- Switch to native pymdownx.superfences mermaid rendering
- Add mermaid-dark.mjs initializer (same fix as eu-digital-product-passport)
- Node labels now readable on slate theme