### PR TITLE
Add nix flake with ontology validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Validate RDF ontology and instances
-        run: |
-          nix run --impure --expr '
-            let pkgs = import (builtins.getFlake "nixpkgs") {};
-                py = pkgs.python3.withPackages (p: [ p.rdflib ]);
-            in pkgs.writeShellScriptBin "validate" "exec ${py}/bin/python3 ontology/validate.py"
-          '
+      - name: Validate RDF ontology
+        run: nix build .#checks.x86_64-linux.ontology

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775525641,
+        "narHash": "sha256-rM50ZJFuc9ePeWX7mgkX3jyqIlJoAdhyGsz5d2xhaTk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dc72a9d2282085d97d5a2cc8e7103a68ed4de188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      python = pkgs.python3.withPackages (p: [ p.rdflib ]);
+    in
+    {
+      checks.${system}.ontology = pkgs.runCommand "validate-ontology"
+        {
+          src = self;
+          nativeBuildInputs = [ python ];
+        }
+        ''
+          cd $src
+          python3 ontology/validate.py
+          touch $out
+        '';
+
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [ python ];
+      };
+    };
+}


### PR DESCRIPTION
Replaces ad-hoc nix expressions with a proper flake. CI runs nix build .#checks.x86_64-linux.ontology.