### PR TITLE
Align ontology with current docs

### DIFF
--- a/ontology/cfr.ttl
+++ b/ontology/cfr.ttl
@@ -176,6 +176,65 @@ cfr:SigningFunction
         Lives on hardware (SE050), phone enclave, server, TEE, or ZK circuit.
         Only its public key and signatures appear on-chain.""" .
 
+# --- Beacon sub-concepts ---
+
+cfr:DataPolicy
+    a owl:Class ;
+    rdfs:label "Data Policy" ;
+    rdfs:comment """The beacon's second payload. Defines who may receive the data
+        (recipient public keys or key classes) and under what conditions. The
+        regulator encodes parameterized disclosure rules in the regulation trie;
+        the beacon carries the applicable rule for each interaction.""" .
+
+cfr:DisclosureContext
+    a owl:Class ;
+    rdfs:label "Disclosure Context" ;
+    rdfs:comment """A parameterized rule that determines encryption recipients
+        based on the purpose of the interaction. Examples: routine reading
+        (owner + regulator), pre-sale disclosure (owner + buyer + regulator),
+        regulatory audit (regulator only), repurposing (both operators +
+        regulator).""" .
+
+cfr:RoutineContext       a cfr:DisclosureContext ; rdfs:label "Routine Reading" ;
+    rdfs:comment "Every beacon — recipients: owner + regulator." .
+cfr:PreSaleContext       a cfr:DisclosureContext ; rdfs:label "Pre-sale Disclosure" ;
+    rdfs:comment "Owner requests — recipients: owner + prospective buyer + regulator." .
+cfr:AuditContext         a cfr:DisclosureContext ; rdfs:label "Regulatory Audit" ;
+    rdfs:comment "Regulator requests — recipients: regulator only." .
+cfr:RepurposingContext   a cfr:DisclosureContext ; rdfs:label "Repurposing Assessment" ;
+    rdfs:comment "Either party requests — recipients: original owner + new operator + regulator." .
+cfr:RecallContext        a cfr:DisclosureContext ; rdfs:label "Emergency Recall" ;
+    rdfs:comment "Regulator requests — recipients: all affected owners + regulator." .
+
+# --- Bright line lifecycle ---
+
+cfr:BrightLinePhase
+    a owl:Class ;
+    rdfs:label "Bright Line Phase" ;
+    rdfs:comment """A phase in the lifecycle of an on-chain hash's personal data
+        status. The hash transitions from personal data (with lawful basis) to
+        anonymous data (outside GDPR scope) when the off-chain pre-image is
+        deleted.""" .
+
+cfr:ActivePhase          a cfr:BrightLinePhase ; rdfs:label "Active Compliance" ;
+    rdfs:comment """Pre-image exists. Hash is personal data under Breyer
+        (C-582/14). Processing lawful under Art 6(1)(c).""" .
+cfr:RetentionPhase       a cfr:BrightLinePhase ; rdfs:label "Retention under Exception" ;
+    rdfs:comment """Pre-image retained for legal claims defence. Hash is
+        personal data. Lawful under Art 17(3)(e).""" .
+cfr:PostErasurePhase     a cfr:BrightLinePhase ; rdfs:label "Post-Erasure" ;
+    rdfs:comment """Pre-image deleted. Hash is unlinkable — anonymous under
+        Recital 26. Outside GDPR scope.""" .
+
+# --- Tension / residual risk ---
+
+cfr:Tension
+    a owl:Class ;
+    rdfs:label "Tension" ;
+    rdfs:comment """A conflict between a GDPR principle and a blockchain
+        architectural property. Each tension has a standard framing, the
+        architecture's response, and a residual risk.""" .
+
 # --- Protocol patterns ---
 
 cfr:ProtocolPattern
@@ -329,6 +388,8 @@ cfr:AccessTier
     rdfs:comment "Visibility level for a data element." .
 
 cfr:PublicAccess      a cfr:AccessTier ; rdfs:label "Public" .
+cfr:RestrictedAccess  a cfr:AccessTier ; rdfs:label "Restricted" ;
+    rdfs:comment "Restricted to the lawful holder and parties expressly entitled by the regulation." .
 cfr:AuthorizedAccess  a cfr:AccessTier ; rdfs:label "Authorized Operators" .
 cfr:AuthorityAccess   a cfr:AccessTier ; rdfs:label "Authorities Only" .
 
@@ -784,6 +845,66 @@ cfr:readsAsReference
     rdfs:domain cfr:SmartContract ;
     rdfs:range cfr:Trie ;
     rdfs:label "reads as reference input" .
+
+# --- Beacon data policy ---
+
+cfr:hasDataPolicy
+    a owl:ObjectProperty ;
+    rdfs:domain cfr:Beacon ;
+    rdfs:range cfr:DataPolicy ;
+    rdfs:label "has data policy" ;
+    rdfs:comment "The data policy carried by this beacon." .
+
+cfr:hasDisclosureContext
+    a owl:ObjectProperty ;
+    rdfs:domain cfr:DataPolicy ;
+    rdfs:range cfr:DisclosureContext ;
+    rdfs:label "has disclosure context" ;
+    rdfs:comment "A disclosure context permitted by this data policy." .
+
+# --- Bright line ---
+
+cfr:hasBrightLinePhase
+    a owl:ObjectProperty ;
+    rdfs:domain cfr:Regulation ;
+    rdfs:range cfr:BrightLinePhase ;
+    rdfs:label "has bright line phase" ;
+    rdfs:comment "A phase in the hash personal-data lifecycle for this regulation." .
+
+# --- Tension ---
+
+cfr:hasTension
+    a owl:ObjectProperty ;
+    rdfs:domain cfr:Regulation ;
+    rdfs:range cfr:Tension ;
+    rdfs:label "has tension" .
+
+cfr:tensionLabel
+    a owl:DatatypeProperty ;
+    rdfs:domain cfr:Tension ;
+    rdfs:range xsd:string ;
+    rdfs:label "tension label" .
+
+cfr:standardFraming
+    a owl:DatatypeProperty ;
+    rdfs:domain cfr:Tension ;
+    rdfs:range xsd:string ;
+    rdfs:label "standard framing" ;
+    rdfs:comment "How the literature frames this tension." .
+
+cfr:architectureResponse
+    a owl:DatatypeProperty ;
+    rdfs:domain cfr:Tension ;
+    rdfs:range xsd:string ;
+    rdfs:label "architecture response" ;
+    rdfs:comment "How this architecture addresses the tension." .
+
+cfr:residualRisk
+    a owl:DatatypeProperty ;
+    rdfs:domain cfr:Tension ;
+    rdfs:range xsd:string ;
+    rdfs:label "residual risk" ;
+    rdfs:comment "The remaining risk after the architecture addresses the tension." .
 
 # --- Cross-regulation ---
 

--- a/ontology/instances/battery-regulation.ttl
+++ b/ontology/instances/battery-regulation.ttl
@@ -50,7 +50,7 @@ bat:BatteryRegulation
                           bat:Repurpose ;
 
     # Penalty
-    cfr:hasPenalty bat:Art77Penalty .
+    cfr:hasPenalty bat:Art93Penalty .
 
 # =============================================================================
 # Parties
@@ -144,9 +144,9 @@ bat:SoHReading
     cfr:deadline "Monthly at most — event-driven on tap" ;
     cfr:implementedBy cfr:CommitmentThenSubmit ;
     cfr:hasDataType cfr:DynamicData ;
-    cfr:hasAccessTier cfr:PublicAccess ;
+    cfr:hasAccessTier cfr:RestrictedAccess ;
     cfr:producesRecord bat:SoHLeaf ;
-    rdfs:comment "Core obligation. SE050 signs COSE_Sign1 with SoH, SoC, cycles, voltage, temperature." .
+    rdfs:comment "Core obligation. SE050 signs COSE_Sign1 with SoH, SoC, cycles, voltage, temperature. Access restricted to lawful purchaser and expressly entitled parties." .
 
 bat:SoHLeaf
     a cfr:ComplianceRecord ;
@@ -189,7 +189,7 @@ bat:SupplyChainAudit
 bat:RepurposingRecord
     a cfr:Obligation ;
     cfr:obligationLabel "Repurposing record" ;
-    cfr:legalBasis "Art 77(6a)" ;
+    cfr:legalBasis "Art 77(3) — new battery passport for repurposed batteries" ;
     cfr:deadline "At repurposing event" ;
     cfr:implementedBy cfr:CrossOperatorHandoff ;
     cfr:hasDataType cfr:EventDrivenData ;
@@ -199,7 +199,7 @@ bat:RepurposingRecord
 bat:EndOfLifeDeclaration
     a cfr:Obligation ;
     cfr:obligationLabel "End of life declaration" ;
-    cfr:legalBasis "Art 77(6b)" ;
+    cfr:legalBasis "Art 77(5) — passport ceases to exist on recycling" ;
     cfr:deadline "At recycling" ;
     cfr:implementedBy cfr:LifecycleStateMachine ;
     cfr:hasDataType cfr:EventDrivenData ;
@@ -309,7 +309,7 @@ bat:G_MPTTransition     a cfr:Guard ; cfr:guardDescription "MPT transition proof
 # Penalty
 # =============================================================================
 
-bat:Art77Penalty
+bat:Art93Penalty
     a cfr:Penalty ;
     cfr:penaltyDescription "Art. 93 Member State penalties, plus market restriction or withdrawal measures under the regulation" ;
     cfr:maxFine "Member State defined — includes product ban" .

--- a/ontology/instances/gdpr.ttl
+++ b/ontology/instances/gdpr.ttl
@@ -273,7 +273,7 @@ gdpr:TR_ControllerSA
     cfr:trustPartyB gdpr:SupervisoryAuthority ;
     cfr:hasTrustLevel cfr:MediumTrust ;
     cfr:trustRisk "Controller backdates breach notification" ;
-    cfr:blockchainMitigates "Commitment proves on-chain ordering and submission slot" .
+    cfr:blockchainMitigates "Commitment proves on-chain ordering and submission slot once the controller commits" .
 
 gdpr:TR_ControllerProcessor
     a cfr:TrustRelationship ;
@@ -386,6 +386,78 @@ gdpr:Tier2Fine
     a cfr:Penalty ;
     cfr:penaltyDescription "Processing principles, data subject rights, transfers (Art 5, 6, 7, 9, 12-22, 44-49)" ;
     cfr:maxFine "€20,000,000 or 4% global turnover" .
+
+# =============================================================================
+# Bright line lifecycle
+# =============================================================================
+
+gdpr:GDPR
+    cfr:hasBrightLinePhase cfr:ActivePhase, cfr:RetentionPhase, cfr:PostErasurePhase .
+
+# =============================================================================
+# GDPR–blockchain tensions
+# =============================================================================
+
+gdpr:GDPR
+    cfr:hasTension gdpr:T_Erasure, gdpr:T_Rectification, gdpr:T_Storage,
+                   gdpr:T_Minimisation, gdpr:T_Controller, gdpr:T_CrossBorder,
+                   gdpr:T_AutomatedDecision, gdpr:T_LegalBasis .
+
+gdpr:T_Erasure
+    a cfr:Tension ;
+    cfr:tensionLabel "Immutability vs erasure (Art 17)" ;
+    cfr:standardFraming "Cannot delete on-chain personal data" ;
+    cfr:architectureResponse "Delete the off-chain pre-image. The on-chain hash becomes unlinkable — anonymous under Recital 26." ;
+    cfr:residualRisk "If the controller fails to delete all copies of the pre-image, the hash remains personal data." .
+
+gdpr:T_Rectification
+    a cfr:Tension ;
+    cfr:tensionLabel "Immutability vs rectification (Art 16)" ;
+    cfr:standardFraming "Cannot correct on-chain records" ;
+    cfr:architectureResponse "Compliance records are appended (new leaf for correction). History of corrections is accountability evidence." ;
+    cfr:residualRisk "Original hash persists alongside correction. Original pre-image should be deleted." .
+
+gdpr:T_Storage
+    a cfr:Tension ;
+    cfr:tensionLabel "Storage limitation (Art 5(1)(e))" ;
+    cfr:standardFraming "On-chain data persists forever" ;
+    cfr:architectureResponse "Active phase: legitimate retention under Art 6(1)(c). After retention period: delete pre-image, hash becomes anonymous." ;
+    cfr:residualRisk "Controller must track retention periods and actually delete pre-images when they expire." .
+
+gdpr:T_Minimisation
+    a cfr:Tension ;
+    cfr:tensionLabel "Data minimisation (Art 5(1)(c))" ;
+    cfr:standardFraming "Full node replication" ;
+    cfr:architectureResponse "Only hashes on-chain — one fixed-size hash per compliance record." ;
+    cfr:residualRisk "Low." .
+
+gdpr:T_Controller
+    a cfr:Tension ;
+    cfr:tensionLabel "Controller designation" ;
+    cfr:standardFraming "Who is the controller on a public chain?" ;
+    cfr:architectureResponse "The data controller is the operator of their own trie. Post-erasure the hash is anonymous and the question is moot." ;
+    cfr:residualRisk "During active phase the controller is clearly identifiable." .
+
+gdpr:T_CrossBorder
+    a cfr:Tension ;
+    cfr:tensionLabel "Cross-border transfers (Art 44-49)" ;
+    cfr:standardFraming "Nodes worldwide = transfer to every jurisdiction" ;
+    cfr:architectureResponse "During active phase: controller is the only party holding the link. Post-erasure: anonymous data, no transfer concern." ;
+    cfr:residualRisk "Breyer argument could theoretically apply to chain nodes during active phase, but nodes have no practical means to obtain the pre-image." .
+
+gdpr:T_AutomatedDecision
+    a cfr:Tension ;
+    cfr:tensionLabel "Automated decision-making (Art 22)" ;
+    cfr:standardFraming "Smart contracts make autonomous decisions" ;
+    cfr:architectureResponse "The smart contract validates format and timing. It does not make decisions about data subjects." ;
+    cfr:residualRisk "Low. No profiling, no legal effects on individuals." .
+
+gdpr:T_LegalBasis
+    a cfr:Tension ;
+    cfr:tensionLabel "Legal basis" ;
+    cfr:standardFraming "No clean basis for on-chain personal data" ;
+    cfr:architectureResponse "Active phase: Art 6(1)(c) — legal obligation to maintain compliance records. Post-erasure: no basis needed — data is anonymous." ;
+    cfr:residualRisk "Legal obligation basis must be established per jurisdiction." .
 
 # =============================================================================
 # Cross-regulation references


### PR DESCRIPTION
Fixes all discrepancies found in ontology audit:
- Battery SoH: PublicAccess → RestrictedAccess
- Battery penalty: Art77 → Art93
- GDPR breach mitigation precision
- New classes: DataPolicy, DisclosureContext, BrightLinePhase, Tension
- New access tier: RestrictedAccess
- GDPR instance: 3 bright line phases, 8 tensions with residual risk
- 1226 triples (was 1098)