### PR TITLE
Add ontology viewer: graph-browser rendering TTL directly

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,14 @@ jobs:
       - name: Generate pages from ontology
         run: nix develop .#default --quiet -c python3 ontology/render.py
 
+      - name: Build ontology viewer
+        run: nix build .#ontology-viewer
+
       - name: Build docs
         run: nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs build --strict
+
+      - name: Copy ontology viewer into site
+        run: mkdir -p site/viewer && cp -r result/* site/viewer/
+
       - name: Deploy docs
         run: nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs gh-deploy --force

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,9 @@
+# Ontology Graph
+
+<div style="position: relative; width: 100%; height: 80vh; border: 1px solid #30363d; border-radius: 8px; overflow: hidden;">
+  <iframe src="../viewer/" style="width: 100%; height: 100%; border: none;"></iframe>
+</div>
+
+*Interactive view of the framework ontology rendered from
+[RDF/Turtle](https://github.com/lambdasistemi/cardano-for-regulators/tree/main/ontology).
+Click a node to explore, use the depth slider to expand.*

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,131 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "graph-browser": {
+      "inputs": {
+        "mkSpagoDerivation": "mkSpagoDerivation",
+        "nixpkgs": "nixpkgs_2",
+        "purescript-overlay": "purescript-overlay"
+      },
+      "locked": {
+        "lastModified": 1775581213,
+        "narHash": "sha256-K153oapYQ7tWBq1oLnm/jkaSr8qLHCAFFupvaJUMJrg=",
+        "owner": "lambdasistemi",
+        "repo": "graph-browser",
+        "rev": "2f5c1b9dfe33721eebcba28dcda1f500cae8607d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lambdasistemi",
+        "repo": "graph-browser",
+        "type": "github"
+      }
+    },
+    "mkSpagoDerivation": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "graph-browser",
+          "nixpkgs"
+        ],
+        "ps-overlay": "ps-overlay",
+        "registry": "registry",
+        "registry-index": "registry-index"
+      },
+      "locked": {
+        "lastModified": 1774754729,
+        "narHash": "sha256-w8D9fPrRHP39Q/Zunm3mU/u/rM1z3NHiTkWrJvCoZx4=",
+        "owner": "jeslie0",
+        "repo": "mkSpagoDerivation",
+        "rev": "a83161ae4e8fb603d06ab434c8462e16d70f73d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "mkSpagoDerivation",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1765762245,
+        "narHash": "sha256-3iXM/zTqEskWtmZs3gqNiVtRTsEjYAedIaLL0mSBsrk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c8cfcd6ccd422e41cc631a0b73ed4d5a925c393d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1775525641,
         "narHash": "sha256-rM50ZJFuc9ePeWX7mgkX3jyqIlJoAdhyGsz5d2xhaTk=",
@@ -16,9 +141,84 @@
         "type": "github"
       }
     },
+    "ps-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1773587485,
+        "narHash": "sha256-hgL4SGSg6pBK9EC8RQFEA6Y+dhJU0ZByG+o/PYdkVmY=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "0a45ee1adbadbda0273b11cd4cc22a68408c73ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "graph-browser",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775137361,
+        "narHash": "sha256-TP7e1+K6CXlpin2bxF97rwLASJXrXZDdZNKmkj1flM0=",
+        "owner": "paolino",
+        "repo": "purescript-overlay",
+        "rev": "e1f4cc532a849d959b24224d13e934d5926e0340",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paolino",
+        "ref": "fix/remove-nodePackages",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "registry": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774753695,
+        "narHash": "sha256-3xbCYMC7GfELzCjkR5DVN0hTnFDrstETpbTf+/AqNss=",
+        "owner": "purescript",
+        "repo": "registry",
+        "rev": "74d581340858adc856b0acd0276c98e7eaac34dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purescript",
+        "repo": "registry",
+        "type": "github"
+      }
+    },
+    "registry-index": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774750363,
+        "narHash": "sha256-cLiPD5NOfxv4Kal9m8sEkhxv2p5OWTc1Lw9e5OfeVIY=",
+        "owner": "purescript",
+        "repo": "registry-index",
+        "rev": "9584a99134e8ec3d9d7d22cc1c1f566a2986e20a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purescript",
+        "repo": "registry-index",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "graph-browser": "graph-browser",
+        "nixpkgs": "nixpkgs_3"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,15 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    graph-browser.url = "github:lambdasistemi/graph-browser";
+  };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, graph-browser }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
       python = pkgs.python3.withPackages (p: [ p.rdflib ]);
+      viewer = graph-browser.packages.${system}.lib;
     in
     {
       checks.${system}.ontology = pkgs.runCommand "validate-ontology"
@@ -17,6 +21,22 @@
           cd $src
           python3 ontology/validate.py
           touch $out
+        '';
+
+      # Ontology viewer: graph-browser lib + combined TTL + config
+      packages.${system}.ontology-viewer = pkgs.runCommand "ontology-viewer"
+        {
+          src = self;
+        }
+        ''
+          mkdir -p $out/data
+          cp ${viewer}/index.html $out/
+          cp ${viewer}/index.js $out/
+          cp $src/ontology/viewer-config.json $out/data/config.json
+          cat $src/ontology/cfr.ttl \
+              $src/ontology/instances/*.ttl \
+              $src/ontology/display.ttl \
+              > $out/data/ontology.ttl
         '';
 
       devShells.${system}.default = pkgs.mkShell {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Ontology Graph: graph.md
   - The Thesis: thesis.md
   - Framework:
       - The Regulator Schema: framework/schema.md

--- a/ontology/display.ttl
+++ b/ontology/display.ttl
@@ -1,0 +1,369 @@
+@prefix cfr:    <https://lambdasistemi.github.io/cardano-for-regulators/ontology#> .
+@prefix gdpr:   <https://lambdasistemi.github.io/cardano-for-regulators/ontology/gdpr#> .
+@prefix bat:    <https://lambdasistemi.github.io/cardano-for-regulators/ontology/battery#> .
+@prefix gb:     <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbk:    <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbg:    <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+
+# =============================================================================
+# Graph-browser display annotations for the CFR ontology.
+# Layers on top of cfr.ttl + instances — does not modify core OWL definitions.
+# =============================================================================
+
+# --- Groups ---
+
+gbg:schema       gb:groupId "schema" .
+gbg:protocol     gb:groupId "protocol" .
+gbg:constraint   gb:groupId "constraint" .
+gbg:gdpr         gb:groupId "gdpr" .
+gbg:battery      gb:groupId "battery" .
+gbg:mechanism    gb:groupId "mechanism" .
+gbg:tension      gb:groupId "tension" .
+
+# =============================================================================
+# Schema parties
+# =============================================================================
+
+cfr:RegulatorRole         a gb:Node, gbk:party ;
+    gb:nodeId "regulator-role" ; gb:group gbg:schema ;
+    rdfs:label "Regulator" ;
+    gb:description "Defines rules. Maintains regulation trie and publishes the smart contract." .
+
+cfr:IdentityProviderRole  a gb:Node, gbk:party ;
+    gb:nodeId "identity-provider-role" ; gb:group gbg:schema ;
+    rdfs:label "Identity Provider" ;
+    gb:description "Maintains the identity trie of verified real-world entities." .
+
+cfr:OperatorRole          a gb:Node, gbk:party ;
+    gb:nodeId "operator-role" ; gb:group gbg:schema ;
+    rdfs:label "Operator" ;
+    gb:description "Manages a process trie. Transparent pipe: collects, verifies off-chain, submits, pays fees." .
+
+cfr:UserRole              a gb:Node, gbk:party ;
+    gb:nodeId "user-role" ; gb:group gbg:schema ;
+    rdfs:label "User" ;
+    gb:description "Acts via signing function. No wallet, no ADA, no blockchain knowledge." .
+
+# =============================================================================
+# On-chain artifacts
+# =============================================================================
+
+cfr:IdentityTrie    a gb:Node, gbk:artifact ;
+    gb:nodeId "identity-trie" ; gb:group gbg:schema ;
+    rdfs:label "Identity Trie" ;
+    gb:description "Attested actor public keys. Maintained by the identity provider." .
+
+cfr:RegulationTrie  a gb:Node, gbk:artifact ;
+    gb:nodeId "regulation-trie" ; gb:group gbg:schema ;
+    rdfs:label "Regulation Trie" ;
+    gb:description "Actor qualifications and operator standing. Maintained by the regulator." .
+
+cfr:ProcessTrie     a gb:Node, gbk:artifact ;
+    gb:nodeId "process-trie" ; gb:group gbg:schema ;
+    rdfs:label "Process Trie" ;
+    gb:description "Items, processes, and state. One per operator. Governed by the smart contract." .
+
+cfr:SmartContract   a gb:Node, gbk:artifact ;
+    gb:nodeId "smart-contract" ; gb:group gbg:schema ;
+    rdfs:label "Smart Contract" ;
+    gb:description "The regulation in executable form. Plutus validator. Reads identity and regulation tries as reference inputs." .
+
+# =============================================================================
+# Schema mechanisms
+# =============================================================================
+
+cfr:Beacon          a gb:Node, gbk:mechanism ;
+    gb:nodeId "beacon" ; gb:group gbg:mechanism ;
+    rdfs:label "Beacon" ;
+    gb:description "Regulator's policy carrier. Forces operator to sample standing and data policy before collecting attestations." .
+
+cfr:SigningFunction a gb:Node, gbk:mechanism ;
+    gb:nodeId "signing-function" ; gb:group gbg:mechanism ;
+    rdfs:label "Signing Function" ;
+    gb:description "Off-chain opaque capability that produces signatures. Hardware SE, phone enclave, server, TEE, or ZK circuit." .
+
+# =============================================================================
+# Protocol patterns
+# =============================================================================
+
+cfr:CommitmentThenSubmit    a gb:Node, gbk:protocol ;
+    gb:nodeId "commitment-then-submit" ; gb:group gbg:protocol ;
+    rdfs:label "Commitment-then-Submit" ;
+    gb:description "Proves an action occurred within a time window. Single-use, slot-bounded." .
+
+cfr:LifecycleStateMachine   a gb:Node, gbk:protocol ;
+    gb:nodeId "lifecycle-state-machine" ; gb:group gbg:protocol ;
+    rdfs:label "Lifecycle State Machine" ;
+    gb:description "Status field in MPT leaf with on-chain validated transitions. No backward transitions." .
+
+cfr:MPTPerOperator          a gb:Node, gbk:protocol ;
+    gb:nodeId "mpt-per-operator" ; gb:group gbg:protocol ;
+    rdfs:label "MPT-per-Operator" ;
+    gb:description "One UTxO per operator, items as leaves. Cost scales with operators not items." .
+
+cfr:DoubleSignature         a gb:Node, gbk:protocol ;
+    gb:nodeId "double-signature" ; gb:group gbg:protocol ;
+    rdfs:label "Double Signature" ;
+    gb:description "Every transition requires process signature (authentication) and actor signature (authorization)." .
+
+cfr:BatonPattern            a gb:Node, gbk:protocol ;
+    gb:nodeId "baton-pattern" ; gb:group gbg:protocol ;
+    rdfs:label "Baton Pattern" ;
+    gb:description "Authorization travels as a baton. Actor A's final submission includes Actor B's pubkey." .
+
+cfr:BeaconGatedAttestation  a gb:Node, gbk:protocol ;
+    gb:nodeId "beacon-gated-attestation" ; gb:group gbg:protocol ;
+    rdfs:label "Beacon-Gated Attestation" ;
+    gb:description "Operator cannot collect attestations without a current beacon carrying standing and data policy." .
+
+cfr:CrossOperatorHandoff    a gb:Node, gbk:protocol ;
+    gb:nodeId "cross-operator-handoff" ; gb:group gbg:protocol ;
+    rdfs:label "Cross-Operator Handoff" ;
+    gb:description "Responsibility transfer. Old leaf read-only, new leaf with back-link to original root." .
+
+cfr:RelayStateMachine       a gb:Node, gbk:protocol ;
+    gb:nodeId "relay-state-machine" ; gb:group gbg:protocol ;
+    rdfs:label "Relay State Machine" ;
+    gb:description "Multiple actors act in sequence. The regulation defines the ordering." .
+
+cfr:RewardDistribution      a gb:Node, gbk:protocol ;
+    gb:nodeId "reward-distribution" ; gb:group gbg:protocol ;
+    rdfs:label "Reward Distribution" ;
+    gb:description "Monotonically increasing reward accumulator in MPT leaf." .
+
+cfr:TieredAccess            a gb:Node, gbk:protocol ;
+    gb:nodeId "tiered-access" ; gb:group gbg:protocol ;
+    rdfs:label "Tiered Access" ;
+    gb:description "On-chain root hash only. Off-chain encrypted layers per access tier." .
+
+cfr:UpstreamVerification    a gb:Node, gbk:protocol ;
+    gb:nodeId "upstream-verification" ; gb:group gbg:protocol ;
+    rdfs:label "Upstream Verification" ;
+    gb:description "One operator's compliance depends on reading another operator's trie." .
+
+# =============================================================================
+# Constraints
+# =============================================================================
+
+cfr:DataCadence        a gb:Node, gbk:constraint ;
+    gb:nodeId "data-cadence" ; gb:group gbg:constraint ;
+    rdfs:label "Data Cadence" ;
+    gb:description "Update rhythm compatible with L1 settlement." .
+
+cfr:SequentialAccess   a gb:Node, gbk:constraint ;
+    gb:nodeId "sequential-access" ; gb:group gbg:constraint ;
+    rdfs:label "Sequential Access" ;
+    gb:description "No concurrent contention on the same data structure." .
+
+cfr:Liveness           a gb:Node, gbk:constraint ;
+    gb:nodeId "liveness" ; gb:group gbg:constraint ;
+    rdfs:label "Liveness" ;
+    gb:description "Deadlines and penalties incentivize participation." .
+
+cfr:FeeAlignment       a gb:Node, gbk:constraint ;
+    gb:nodeId "fee-alignment" ; gb:group gbg:constraint ;
+    rdfs:label "Fee Alignment" ;
+    gb:description "An actor benefits enough to sponsor on-chain activity." .
+
+cfr:IdentityDelegation a gb:Node, gbk:constraint ;
+    gb:nodeId "identity-delegation" ; gb:group gbg:constraint ;
+    rdfs:label "Identity Delegation" ;
+    gb:description "Non-crypto actors participate via cryptographic proxies." .
+
+# =============================================================================
+# Case studies
+# =============================================================================
+
+gdpr:GDPR              a gb:Node, gbk:case-study ;
+    gb:nodeId "gdpr" ; gb:group gbg:gdpr ;
+    rdfs:label "GDPR" ;
+    gb:description "EU 2016/679. Compliance evidence on-chain, personal data off-chain. Process mode." .
+
+bat:BatteryRegulation   a gb:Node, gbk:case-study ;
+    gb:nodeId "battery-regulation" ; gb:group gbg:battery ;
+    rdfs:label "EU Battery Regulation" ;
+    gb:description "EU 2023/1542. Product passport with NFC secure element. Physical mode." .
+
+# =============================================================================
+# GDPR concrete parties
+# =============================================================================
+
+gdpr:SupervisoryAuthority a gb:Node, gbk:gdpr-party ;
+    gb:nodeId "gdpr-sa" ; gb:group gbg:gdpr ;
+    rdfs:label "Supervisory Authority" ;
+    gb:description "National DPA. Maps to Regulator role." .
+
+gdpr:DataController     a gb:Node, gbk:gdpr-party ;
+    gb:nodeId "gdpr-controller" ; gb:group gbg:gdpr ;
+    rdfs:label "Data Controller" ;
+    gb:description "Determines purposes and means of processing. Maps to Operator role." .
+
+gdpr:DataSubject        a gb:Node, gbk:gdpr-party ;
+    gb:nodeId "gdpr-subject" ; gb:group gbg:gdpr ;
+    rdfs:label "Data Subject" ;
+    gb:description "Identified or identifiable natural person. Maps to User role." .
+
+# =============================================================================
+# GDPR key obligations
+# =============================================================================
+
+gdpr:BreachNotification72h a gb:Node, gbk:obligation ;
+    gb:nodeId "gdpr-breach-72h" ; gb:group gbg:gdpr ;
+    rdfs:label "Breach Notification (72h)" ;
+    gb:description "Art 33. Controller notifies SA within 72 hours. Flagship commitment-then-submit use case." .
+
+gdpr:RightsResponse1m   a gb:Node, gbk:obligation ;
+    gb:nodeId "gdpr-rights-1m" ; gb:group gbg:gdpr ;
+    rdfs:label "Rights Response (1 month)" ;
+    gb:description "Art 12-22. Controller responds to data subject rights within 1 month." .
+
+gdpr:ConsentRecord      a gb:Node, gbk:obligation ;
+    gb:nodeId "gdpr-consent" ; gb:group gbg:gdpr ;
+    rdfs:label "Consent Lifecycle" ;
+    gb:description "Art 7. None → Given → Withdrawn. Each transition timestamped on-chain." .
+
+# =============================================================================
+# GDPR tensions
+# =============================================================================
+
+gdpr:T_Erasure          a gb:Node, gbk:tension ;
+    gb:nodeId "tension-erasure" ; gb:group gbg:tension ;
+    rdfs:label "Immutability vs Erasure" ;
+    gb:description "Art 17. Delete off-chain pre-image → on-chain hash becomes anonymous under Recital 26." .
+
+# =============================================================================
+# Bright line phases
+# =============================================================================
+
+cfr:ActivePhase         a gb:Node, gbk:concept ;
+    gb:nodeId "bright-line-active" ; gb:group gbg:gdpr ;
+    rdfs:label "Active Phase" ;
+    gb:description "Pre-image exists. Hash is personal data under Breyer. Lawful under Art 6(1)(c)." .
+
+cfr:PostErasurePhase    a gb:Node, gbk:concept ;
+    gb:nodeId "bright-line-post-erasure" ; gb:group gbg:gdpr ;
+    rdfs:label "Post-Erasure Phase" ;
+    gb:description "Pre-image deleted. Hash is unlinkable — anonymous under Recital 26. Outside GDPR scope." .
+
+# =============================================================================
+# Battery concrete parties
+# =============================================================================
+
+bat:Manufacturer        a gb:Node, gbk:battery-party ;
+    gb:nodeId "bat-manufacturer" ; gb:group gbg:battery ;
+    rdfs:label "Manufacturer" ;
+    gb:description "Primary operator. Manages product passport trie. Pays all fees." .
+
+bat:Consumer            a gb:Node, gbk:battery-party ;
+    gb:nodeId "bat-consumer" ; gb:group gbg:battery ;
+    rdfs:label "Consumer" ;
+    gb:description "Taps NFC to trigger SE050 SoH reading. No wallet needed." .
+
+# =============================================================================
+# Battery key obligations
+# =============================================================================
+
+bat:SoHReading          a gb:Node, gbk:obligation ;
+    gb:nodeId "bat-soh" ; gb:group gbg:battery ;
+    rdfs:label "SoH Reading" ;
+    gb:description "Core obligation. SE050 signs COSE_Sign1 with SoH, cycles, voltage, temperature." .
+
+# =============================================================================
+# Edges (gb:EdgeAssertion)
+# =============================================================================
+
+# Schema edges
+_:e1  a gb:EdgeAssertion ; gb:from cfr:RegulatorRole ;   gb:to cfr:RegulationTrie ;  rdfs:label "maintains" ;
+    gb:description "The regulator maintains the regulation trie with standing and data policy." .
+_:e2  a gb:EdgeAssertion ; gb:from cfr:RegulatorRole ;   gb:to cfr:SmartContract ;   rdfs:label "publishes" ;
+    gb:description "Publishes the regulation as a Plutus validator." .
+_:e3  a gb:EdgeAssertion ; gb:from cfr:IdentityProviderRole ; gb:to cfr:IdentityTrie ; rdfs:label "maintains" ;
+    gb:description "Verifies entities and maintains attested public keys." .
+_:e4  a gb:EdgeAssertion ; gb:from cfr:OperatorRole ;    gb:to cfr:ProcessTrie ;     rdfs:label "manages" ;
+    gb:description "Each operator manages their own process trie." .
+_:e5  a gb:EdgeAssertion ; gb:from cfr:OperatorRole ;    gb:to cfr:SigningFunction ;  rdfs:label "mints" ;
+    gb:description "Generates key pairs, registers on-chain, distributes to users." .
+_:e6  a gb:EdgeAssertion ; gb:from cfr:OperatorRole ;    gb:to cfr:Beacon ;          rdfs:label "produces" ;
+    gb:description "Samples standing and data policy from regulation trie." .
+_:e7  a gb:EdgeAssertion ; gb:from cfr:UserRole ;        gb:to cfr:SigningFunction ;  rdfs:label "uses" ;
+    gb:description "Performs regulated actions via the signing function." .
+_:e8  a gb:EdgeAssertion ; gb:from cfr:UserRole ;        gb:to cfr:Beacon ;          rdfs:label "signs over" ;
+    gb:description "Verifies beacon, encrypts data for recipients, signs over it." .
+_:e9  a gb:EdgeAssertion ; gb:from cfr:SmartContract ;   gb:to cfr:ProcessTrie ;     rdfs:label "governs" ;
+    gb:description "Validates every state transition." .
+_:e10 a gb:EdgeAssertion ; gb:from cfr:SmartContract ;   gb:to cfr:IdentityTrie ;    rdfs:label "reads" ;
+    gb:description "Reference input: checks actor is attested." .
+_:e11 a gb:EdgeAssertion ; gb:from cfr:SmartContract ;   gb:to cfr:RegulationTrie ;  rdfs:label "reads" ;
+    gb:description "Reference input: checks actor is qualified." .
+
+# Beacon protocol edges
+_:e12 a gb:EdgeAssertion ; gb:from cfr:BeaconGatedAttestation ; gb:to cfr:Beacon ; rdfs:label "defines" ;
+    gb:description "The pattern defines how beacons are produced and validated." .
+_:e13 a gb:EdgeAssertion ; gb:from cfr:DoubleSignature ; gb:to cfr:SigningFunction ; rdfs:label "uses" ;
+    gb:description "Process signature comes from the signing function." .
+
+# Case study → pattern edges
+_:e20 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:CommitmentThenSubmit ; rdfs:label "uses" ;
+    gb:description "72h breach notification and 1-month rights response." .
+_:e21 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:LifecycleStateMachine ; rdfs:label "uses" ;
+    gb:description "Consent lifecycle: None → Given → Withdrawn." .
+_:e22 a gb:EdgeAssertion ; gb:from bat:BatteryRegulation ; gb:to cfr:CommitmentThenSubmit ; rdfs:label "uses" ;
+    gb:description "Authenticated SoH readings via two-transaction protocol." .
+_:e23 a gb:EdgeAssertion ; gb:from bat:BatteryRegulation ; gb:to cfr:RewardDistribution ; rdfs:label "uses" ;
+    gb:description "Incentivises third-party SoH data collection." .
+_:e24 a gb:EdgeAssertion ; gb:from bat:BatteryRegulation ; gb:to cfr:CrossOperatorHandoff ; rdfs:label "uses" ;
+    gb:description "Repurposing: new leaf in new operator's trie with back-link." .
+
+# Party mapping edges
+_:e30 a gb:EdgeAssertion ; gb:from gdpr:SupervisoryAuthority ; gb:to cfr:RegulatorRole ; rdfs:label "maps to" ;
+    gb:description "The SA maps to the regulator role in the schema." .
+_:e31 a gb:EdgeAssertion ; gb:from gdpr:DataController ; gb:to cfr:OperatorRole ; rdfs:label "maps to" ;
+    gb:description "The data controller maps to the operator role." .
+_:e32 a gb:EdgeAssertion ; gb:from gdpr:DataSubject ; gb:to cfr:UserRole ; rdfs:label "maps to" ;
+    gb:description "The data subject maps to the user role." .
+_:e33 a gb:EdgeAssertion ; gb:from bat:Manufacturer ; gb:to cfr:OperatorRole ; rdfs:label "maps to" ;
+    gb:description "The manufacturer maps to the operator role." .
+_:e34 a gb:EdgeAssertion ; gb:from bat:Consumer ; gb:to cfr:UserRole ; rdfs:label "maps to" ;
+    gb:description "The consumer maps to the user role." .
+
+# Obligation → pattern edges
+_:e40 a gb:EdgeAssertion ; gb:from gdpr:BreachNotification72h ; gb:to cfr:CommitmentThenSubmit ; rdfs:label "implemented by" ;
+    gb:description "The 72h deadline is enforced via the commitment protocol." .
+_:e41 a gb:EdgeAssertion ; gb:from gdpr:RightsResponse1m ; gb:to cfr:CommitmentThenSubmit ; rdfs:label "implemented by" ;
+    gb:description "The 1-month deadline is enforced via the commitment protocol." .
+_:e42 a gb:EdgeAssertion ; gb:from gdpr:ConsentRecord ; gb:to cfr:LifecycleStateMachine ; rdfs:label "implemented by" ;
+    gb:description "Consent transitions modelled as a lifecycle state machine." .
+_:e43 a gb:EdgeAssertion ; gb:from bat:SoHReading ; gb:to cfr:CommitmentThenSubmit ; rdfs:label "implemented by" ;
+    gb:description "Two-transaction protocol for authenticated readings." .
+
+# Constraint → pattern edges
+_:e50 a gb:EdgeAssertion ; gb:from cfr:MPTPerOperator ; gb:to cfr:SequentialAccess ; rdfs:label "satisfies" ;
+    gb:description "One writer per trie — no contention by design." .
+_:e51 a gb:EdgeAssertion ; gb:from cfr:MPTPerOperator ; gb:to cfr:DataCadence ; rdfs:label "satisfies" ;
+    gb:description "One transaction per batch regardless of item count." .
+_:e52 a gb:EdgeAssertion ; gb:from cfr:SigningFunction ; gb:to cfr:IdentityDelegation ; rdfs:label "implements" ;
+    gb:description "Cryptographic proxies for non-crypto actors." .
+
+# Missing pattern edges (were orphans)
+_:e53 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:TieredAccess ; rdfs:label "uses" ;
+    gb:description "On-chain root hash only. Off-chain encrypted layers per access tier." .
+_:e54 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:RelayStateMachine ; rdfs:label "uses" ;
+    gb:description "Rights request follows a relay: subject → controller → response." .
+_:e55 a gb:EdgeAssertion ; gb:from bat:BatteryRegulation ; gb:to cfr:BatonPattern ; rdfs:label "uses" ;
+    gb:description "Ownership baton passes from manufacturer to transporter to consumer." .
+_:e56 a gb:EdgeAssertion ; gb:from cfr:UpstreamVerification ; gb:to cfr:ProcessTrie ; rdfs:label "reads across" ;
+    gb:description "One operator's compliance depends on reading another operator's trie." .
+
+# Missing constraint edges
+_:e57 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:FeeAlignment ; rdfs:label "satisfies" ;
+    gb:description "Controllers pay ~50-100 EUR/year vs potential fines of millions." .
+_:e58 a gb:EdgeAssertion ; gb:from gdpr:GDPR ; gb:to cfr:Liveness ; rdfs:label "satisfies" ;
+    gb:description "Up to 4% global turnover. Strongest liveness incentive of any regulation." .
+
+# Bright line edges
+_:e60 a gb:EdgeAssertion ; gb:from cfr:ActivePhase ; gb:to cfr:PostErasurePhase ; rdfs:label "delete pre-image" ;
+    gb:description "Controller deletes off-chain data. Hash transitions from personal data to anonymous." .
+_:e61 a gb:EdgeAssertion ; gb:from gdpr:T_Erasure ; gb:to cfr:PostErasurePhase ; rdfs:label "resolved by" ;
+    gb:description "Pre-image deletion makes the hash unlinkable. Immutability is not a problem." .

--- a/ontology/viewer-config.json
+++ b/ontology/viewer-config.json
@@ -1,0 +1,22 @@
+{
+  "title": "Cardano for Regulators — Ontology",
+  "description": "Interactive view of the framework ontology: parties, artifacts, patterns, constraints, and case studies.",
+  "sourceUrl": "https://github.com/lambdasistemi/cardano-for-regulators",
+  "kinds": {
+    "party": { "label": "Schema Role", "color": "#58a6ff", "shape": "round-octagon" },
+    "artifact": { "label": "On-chain Artifact", "color": "#d2a8ff", "shape": "round-rectangle" },
+    "mechanism": { "label": "Schema Mechanism", "color": "#f778ba", "shape": "diamond" },
+    "protocol": { "label": "Protocol Pattern", "color": "#f0883e", "shape": "barrel" },
+    "constraint": { "label": "Constraint", "color": "#e3b341", "shape": "round-pentagon" },
+    "case-study": { "label": "Case Study", "color": "#56d364", "shape": "star" },
+    "gdpr-party": { "label": "GDPR Party", "color": "#79c0ff", "shape": "ellipse" },
+    "battery-party": { "label": "Battery Party", "color": "#79c0ff", "shape": "ellipse" },
+    "obligation": { "label": "Obligation", "color": "#f778ba", "shape": "round-rectangle" },
+    "tension": { "label": "Tension", "color": "#f85149", "shape": "triangle" },
+    "concept": { "label": "Concept", "color": "#56d364", "shape": "ellipse" }
+  },
+  "graphSource": {
+    "format": "text/turtle",
+    "path": "data/ontology.ttl"
+  }
+}


### PR DESCRIPTION
Embeds graph-browser in the docs site, loading the ontology from TTL via Oxigraph WASM. 40 nodes, 38 edges, colored by kind.