### PR TITLE
Fix deploy: linear build pipeline

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,17 +20,19 @@ jobs:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Generate pages from ontology
-        run: nix develop .#default --quiet -c python3 ontology/render.py
+      - name: Build site
+        run: |
+          # 1. Generate markdown pages from ontology
+          nix develop .#default --quiet -c python3 ontology/render.py
 
-      - name: Build ontology viewer
-        run: nix build .#ontology-viewer
+          # 2. Build mkdocs
+          nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs build --strict
 
-      - name: Build docs
-        run: nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs build --strict
+          # 3. Copy ontology viewer into the built site
+          nix build .#ontology-viewer
+          mkdir -p site/viewer/data
+          cp result/index.html result/index.js site/viewer/
+          cp result/data/* site/viewer/data/
 
-      - name: Copy ontology viewer into site
-        run: mkdir -p site/viewer && cp -r result/* site/viewer/
-
-      - name: Deploy docs
-        run: nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs gh-deploy --force
+      - name: Deploy site
+        run: nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c ghp-import site --push --force --no-jekyll


### PR DESCRIPTION
ghp-import replaces mkdocs gh-deploy so the viewer survives.