### PR TITLE
Add unlinkable authorization pattern (BBS+)

### DIFF
--- a/docs/framework/constraints.md
+++ b/docs/framework/constraints.md
@@ -210,3 +210,24 @@ Before running the full five constraints, apply this quick filter:
 
 If all three hold → proceed with the five constraints.
 If only 1-2 hold → a traditional database with audit logs may suffice.
+
+## Tie-breaker: unlinkability requirement
+
+Some regulations pass all five constraints but seem marginal — a traditional
+database with strong access controls could arguably suffice. The deciding
+factor may be **unlinkability**: does the regulation require that the operator
+cannot correlate a user's actions across interactions?
+
+If yes, no traditional database achieves this. The operator runs the database
+and can always query it. Access control policies can be circumvented by the
+administrator. Only cryptographic unlinkability — where correlation is
+mathematically impossible, not just forbidden — satisfies the requirement.
+
+Pairing-based anonymous credentials (BBS+) on Cardano provide this. See the
+[unlinkable authorization pattern](patterns.md#unlinkable-authorization-via-anonymous-credentials)
+for details.
+
+This makes the unlinkability requirement a tie-breaker: when the five
+constraints are met but the case for blockchain over a database is weak,
+a regulation that demands unlinkability tips the balance decisively toward
+on-chain infrastructure.

--- a/docs/framework/patterns.md
+++ b/docs/framework/patterns.md
@@ -206,6 +206,74 @@ sequenceDiagram
 expiry has passed or whose standing hash doesn't match the regulation trie
 at mint time.
 
+## Unlinkable authorization via anonymous credentials
+
+**When:** The regulation requires proof of authorization but forbids the
+operator from correlating a user's actions across interactions.
+
+```mermaid
+sequenceDiagram
+    participant R as Regulator / IdP
+    participant U as User
+    participant O as Operator
+    participant C as Chain
+
+    R->>U: Issue BBS+ credential (attests: real user)
+    Note over U: Credential stored locally
+    U->>U: Derive ZK proof from credential
+    U->>O: Submit data + ZK proof (no identity revealed)
+    O->>O: Verify proof: "a real attested user"
+    O->>C: Submit batch (proof as redeemer)
+    Note over O: Cannot link this submission<br/>to any previous one
+```
+
+**Properties:**
+
+- The regulator (or identity provider) issues a BBS+ credential attesting the
+  user is real and authorized
+- The user derives a fresh zero-knowledge proof for each interaction — each
+  proof is unlinkable to previous ones
+- The operator verifies the user is authorized without learning *which* user
+- The operator cannot correlate multiple submissions from the same user
+- The operator cannot fabricate fake users — only the regulator can issue
+  credentials
+- The chain carries the proof as redeemer — publicly verifiable authorization
+  without public identity
+
+**Why this requires pairings:**
+
+BBS+ signatures have algebraic structure (three group elements, pairing-based
+verification) that allows selective disclosure and proof derivation. Standard
+signatures (Ed25519, ECDSA) are opaque blobs — you either reveal the full
+signature or nothing. There is no way to prove "I hold a valid signature from
+authority X" without showing the signature itself, which links you.
+
+Plutus V3 provides BLS12-381 curve primitives (pairing, G1/G2 operations,
+hash-to-curve) which make on-chain BBS+ proof verification feasible.
+
+**Constraint fit:**
+
+- Identity delegation: the credential replaces the public key as proof of
+  authorization — the user still never needs a wallet
+- Fee alignment: operator pays, as before
+- Sequential access: unchanged — operator batches submissions
+
+**When it matters:**
+
+Some regulations explicitly require unlinkability — GDPR's purpose limitation
+(Art. 5(1)(b)) forbids accumulating behavioral profiles from rights exercise.
+Other regulations may not require it, and users may even prefer linkability
+(e.g., battery rewards). This pattern applies when the regulation demands that
+the operator process authorized data without being able to build per-user
+activity profiles.
+
+**Regulatory differentiator:** This pattern can determine feasibility. When a
+regulation mandates both verifiable authorization and user unlinkability, plain
+public-key schemes fail — the operator can always correlate by key. Anonymous
+credentials make the regulation tractable on-chain. Without them, the only
+alternative is trusting the operator not to correlate — which is policy, not
+construction.
+
 ## Identity delegation via hardware
 
 **When:** Non-crypto actors must make on-chain state transitions.

--- a/docs/framework/schema.md
+++ b/docs/framework/schema.md
@@ -866,6 +866,25 @@ the actual data behind the leaves is verified off-chain by the operator.
 The on-chain proofs (signatures, trie membership) establish *that* the
 right things happened without revealing *what* the actual content is.
 
+### Unlinkability
+
+The privacy model above prevents the operator from knowing real identities,
+but does not prevent correlation. When the same public key appears across
+multiple transactions, the operator can link all actions from that user —
+building activity profiles, identifying patterns, inferring behavior.
+
+For regulations that forbid this (e.g., GDPR Art. 5(1)(b) purpose limitation),
+structural privacy is insufficient. The *unlinkable authorization* pattern
+(see [Architecture Patterns](patterns.md#unlinkable-authorization-via-anonymous-credentials))
+closes this gap: the identity provider issues BBS+ credentials, and the user
+derives a fresh zero-knowledge proof for each interaction. The operator
+verifies authorization without being able to correlate submissions from the
+same user.
+
+This strengthens the privacy table: the operator not only doesn't know
+identities — they cannot even tell whether two authorized actions came from
+the same person.
+
 ## Data availability and the burden of proof
 
 The tries store hashes on-chain, not full content. There is no guarantee


### PR DESCRIPTION
## Summary

- New architecture pattern: **unlinkable authorization via anonymous credentials** (BBS+ on BLS12-381)
- Updated privacy model in schema.md with unlinkability subsection
- Added unlinkability as tie-breaker in constraint analysis

The pattern addresses regulations (e.g. GDPR Art. 5(1)(b)) that require the operator to verify user authorization without being able to correlate their actions across interactions. This is impossible with standard public-key schemes and traditional databases — only pairing-based anonymous credentials provide cryptographic unlinkability.